### PR TITLE
Add inverted-index scoring and shared BM25 optimization modules.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,26 @@ permissions:
 
 jobs:
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Create virtualenv
+        run: python -m venv .venv
+      - name: Install dependencies
+        run: |
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install maturin pytest pytest-benchmark numpy
+      - name: Build extension
+        run: .venv/bin/maturin develop --release
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+      - name: Run tests
+        run: .venv/bin/pytest tests/ -v --benchmark-disable
+
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,16 +22,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bitflags"
-version = "2.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
-
-[[package]]
 name = "bm25-rs"
-version = "1.0.0"
+version = "1.0.5"
 dependencies = [
  "ahash",
+ "numpy",
  "pyo3",
  "rayon",
  "smallvec",
@@ -76,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,18 +90,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
@@ -115,13 +116,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
+name = "matrixmultiply"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
- "scopeguard",
+ "rawpointer",
 ]
 
 [[package]]
@@ -134,39 +135,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb929bc0da91a4d85ed6c0a84deaa53d411abfb387fc271124f91bf6b89f14e"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -179,15 +223,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -197,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -207,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -217,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -229,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -256,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,19 +326,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.17"
+name = "rustc-hash"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "serde"
@@ -327,11 +368,10 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "string-interner"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
 dependencies = [
- "cfg-if",
  "hashbrown",
  "serde",
 ]
@@ -388,70 +428,6 @@ checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,13 @@ rayon = "1.1"
 ahash = "0.8"
 smallvec = "1.11"
 string-interner = "0.19"
+numpy = { version = "0.22", optional = true }
+
+[features]
+default = ["numpy"]
+numpy = ["dep:numpy"]
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,7 +17,6 @@ recursive-include python *.py
 recursive-include tests *.py
 
 # Include benchmarks and examples
-recursive-include benchmarks *.py
 recursive-include examples *.py
 
 # Exclude development files

--- a/advanced_benchmark.py
+++ b/advanced_benchmark.py
@@ -40,7 +40,7 @@ def benchmark_initialization(corpus_sizes: List[int]):
         
         # Test Rust BM25Okapi
         try:
-            from bm25_pyrs import BM25Okapi as BM25Rust
+            from bm25_rs import BM25Okapi as BM25Rust
             
             gc.collect()  # Clean memory before test
             start_time = time.time()
@@ -65,7 +65,7 @@ def benchmark_query_performance(corpus_size: int = 10000, num_queries: int = 100
     corpus, vocabulary = generate_realistic_corpus(corpus_size, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi as BM25Rust
+        from bm25_rs import BM25Okapi as BM25Rust
         
         # Initialize
         print("Initializing BM25...")
@@ -117,7 +117,7 @@ def benchmark_concurrent_queries(corpus_size: int = 10000, num_threads: int = 4,
     corpus, vocabulary = generate_realistic_corpus(corpus_size, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi as BM25Rust
+        from bm25_rs import BM25Okapi as BM25Rust
         
         bm25_rust = BM25Rust(corpus)
         
@@ -165,7 +165,7 @@ def benchmark_batch_operations(corpus_size: int = 10000):
     corpus, vocabulary = generate_realistic_corpus(corpus_size, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi as BM25Rust
+        from bm25_rs import BM25Okapi as BM25Rust
         
         bm25_rust = BM25Rust(corpus)
         query = ' '.join(random.choices(vocabulary, k=3))
@@ -215,7 +215,7 @@ def profile_memory_usage():
             corpus, _ = generate_realistic_corpus(size, 100)
             
             try:
-                from bm25_pyrs import BM25Okapi as BM25Rust
+                from bm25_rs import BM25Okapi as BM25Rust
                 bm25_rust = BM25Rust(corpus)
                 
                 # Measure after

--- a/benchmark.py
+++ b/benchmark.py
@@ -33,7 +33,7 @@ def benchmark_bm25():
     
     try:
         # Try to import the optimized Rust version
-        from bm25_pyrs import BM25Okapi as BM25Rust
+        from bm25_rs import BM25Okapi as BM25Rust
         
         print("Testing optimized Rust BM25...")
         start_time = time.time()

--- a/performance_comparison.py
+++ b/performance_comparison.py
@@ -47,7 +47,7 @@ def compare_scoring_methods():
     corpus, queries = generate_test_data(10000, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi
+        from bm25_rs import BM25Okapi
         
         bm25 = BM25Okapi(corpus)
         test_query = queries[0].lower().split()
@@ -92,7 +92,7 @@ def compare_top_n_methods():
     corpus, queries = generate_test_data(10000, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi
+        from bm25_rs import BM25Okapi
         
         bm25 = BM25Okapi(corpus)
         test_query = queries[0].lower().split()
@@ -142,7 +142,7 @@ def benchmark_batch_vs_individual():
     corpus, queries = generate_test_data(5000, 100)
     
     try:
-        from bm25_pyrs import BM25Okapi
+        from bm25_rs import BM25Okapi
         
         bm25 = BM25Okapi(corpus)
         test_queries = [q.lower().split() for q in queries[:50]]
@@ -194,7 +194,7 @@ def memory_efficiency_test():
             corpus, _ = generate_test_data(size, 50)
             
             try:
-                from bm25_pyrs import BM25Okapi
+                from bm25_rs import BM25Okapi
                 
                 start_time = time.time()
                 bm25 = BM25Okapi(corpus)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,13 @@ classifiers = [
     "Topic :: Text Processing :: Indexing",
 ]
 requires-python = ">=3.8"
-dependencies = [
-    "pytest>=8.3.5",
-    "twine>=6.1.0",
-]
-
-[project.urls]
-Homepage = "https://github.com/dorianbrown/rank_bm25"
-Documentation = "https://github.com/dorianbrown/rank_bm25#readme"
-Repository = "https://github.com/dorianbrown/rank_bm25.git"
-"Bug Tracker" = "https://github.com/dorianbrown/rank_bm25/issues"
-Changelog = "https://github.com/dorianbrown/rank_bm25/blob/main/CHANGELOG.md"
+dependencies = []
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
     "pytest-benchmark>=4.0",
+    "twine>=6.1.0",
     "black>=22.0",
     "ruff>=0.1.0",
     "mypy>=1.0",
@@ -62,8 +53,15 @@ benchmark = [
     "numpy>=1.21.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/dorianbrown/rank_bm25"
+Documentation = "https://github.com/dorianbrown/rank_bm25#readme"
+Repository = "https://github.com/dorianbrown/rank_bm25.git"
+"Bug Tracker" = "https://github.com/dorianbrown/rank_bm25/issues"
+Changelog = "https://github.com/dorianbrown/rank_bm25/blob/main/CHANGELOG.md"
+
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["numpy"]
 python-source = "python"
 module-name = "bm25_rs._bm25_rs"
 

--- a/python/bm25_rs/__init__.py
+++ b/python/bm25_rs/__init__.py
@@ -4,9 +4,9 @@ BM25-RS: High-Performance BM25 for Python
 A blazingly fast BM25 implementation in Rust with Python bindings.
 """
 
-from ._bm25_rs import BM25Okapi, BM25Plus, BM25L
+from ._bm25_rs import BM25Okapi, BM25Plus, BM25L, PyPreprocessedQuery
 
-__version__ = "0.1.0"
+__version__ = "1.0.5"
 __author__ = "BM25-RS Team"
 __email__ = "amiya8mandal@gmail.com"
 
@@ -14,6 +14,7 @@ __all__ = [
     "BM25Okapi",
     "BM25Plus",
     "BM25L",
+    "PyPreprocessedQuery",
 ]
 
 # Convenience imports for common use cases

--- a/src/bm25l.rs
+++ b/src/bm25l.rs
@@ -1,10 +1,19 @@
+use crate::index::{
+    build_index, calc_idf_l, tokenize_corpus_parallel, tokenize_corpus_with_py,
+    tokenized_corpus_from_vecs, IndexView,
+};
+use crate::scoring::{
+    preprocess_query, score_all_inverted, score_documents_parallel, score_queries_batch,
+    top_k_inverted, PreprocessedQuery, ScoreFormula, ScoreParams,
+};
+use ahash::AHashMap;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use rayon::prelude::*;
-use ahash::AHashMap;
-use smallvec::SmallVec;
-use string_interner::{StringInterner, DefaultSymbol, DefaultBackend};
 use std::sync::Arc;
+use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
+
+#[cfg(feature = "numpy")]
+use numpy::PyArray1;
 
 /// BM25L structure with necessary fields - optimized version
 #[pyclass]
@@ -19,26 +28,55 @@ pub struct BM25L {
     corpus_size: usize,
     #[pyo3(get)]
     avgdl: f64,
-    // Optimized data structures
     doc_freqs: Arc<Vec<AHashMap<DefaultSymbol, u32>>>,
     idf: Arc<AHashMap<DefaultSymbol, f64>>,
     doc_len: Arc<Vec<u32>>,
+    inverted: Arc<AHashMap<DefaultSymbol, Vec<(u32, u32)>>>,
     interner: Arc<StringInterner<DefaultBackend>>,
     tokenizer: Option<Py<PyAny>>,
-    // Precomputed values
     k1_plus1: f64,
     one_minus_b: f64,
     b_over_avgdl: f64,
 }
 
+impl BM25L {
+    fn score_params(&self) -> ScoreParams {
+        ScoreParams {
+            k1: self.k1,
+            k1_plus1: self.k1_plus1,
+            one_minus_b: self.one_minus_b,
+            b_over_avgdl: self.b_over_avgdl,
+        }
+    }
+
+    fn formula(&self) -> ScoreFormula {
+        ScoreFormula::L { delta: self.delta }
+    }
+
+    fn preprocess(&self, query: &[String]) -> PreprocessedQuery {
+        preprocess_query(query, &self.interner, &self.idf)
+    }
+
+    fn index_view(&self) -> IndexView<'_> {
+        IndexView {
+            doc_freqs: &self.doc_freqs,
+            doc_len: &self.doc_len,
+            inverted: &self.inverted,
+            corpus_size: self.corpus_size,
+            avgdl: self.avgdl,
+        }
+    }
+}
+
 #[pymethods]
 impl BM25L {
     #[new]
-    #[pyo3(signature = (corpus, tokenizer=None, k1=None, b=None, delta=None))]
+    #[pyo3(signature = (corpus=None, tokenizer=None, tokenized_corpus=None, k1=None, b=None, delta=None))]
     pub fn new(
         py: Python,
-        corpus: Vec<String>,
+        corpus: Option<Vec<String>>,
         tokenizer: Option<Bound<PyAny>>,
+        tokenized_corpus: Option<Vec<Vec<String>>>,
         k1: Option<f64>,
         b: Option<f64>,
         delta: Option<f64>,
@@ -47,48 +85,53 @@ impl BM25L {
         let b = b.unwrap_or(0.75);
         let delta = delta.unwrap_or(0.5);
 
-        let tokenizer = tokenizer.map(|tokenizer| tokenizer.into());
-        let mut interner = StringInterner::default();
+        let tokenizer = tokenizer.map(|tk| tk.into());
 
-        // Tokenize corpus with optimization
-        let tokenized_corpus = if let Some(ref tokenizer_py) = tokenizer {
-            Self::tokenize_corpus_with_py(py, &corpus, tokenizer_py)?
-        } else {
-            corpus
-                .par_iter()
-                .map(|doc| {
-                    doc.split_whitespace()
-                        .map(|s| s.to_lowercase())
-                        .collect::<SmallVec<[String; 16]>>()
-                })
-                .collect()
+        let tokenized = match (corpus, tokenized_corpus) {
+            (Some(corpus_docs), None) => {
+                if let Some(ref tokenizer_py) = tokenizer {
+                    tokenize_corpus_with_py(py, &corpus_docs, tokenizer_py)?
+                } else {
+                    py.allow_threads(|| tokenize_corpus_parallel(&corpus_docs))
+                }
+            }
+            (None, Some(tokens)) => tokenized_corpus_from_vecs(tokens),
+            (Some(_), Some(_)) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Provide either corpus or tokenized_corpus, not both.",
+                ));
+            }
+            (None, None) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Either corpus or tokenized_corpus must be provided.",
+                ));
+            }
         };
 
-        let corpus_size = tokenized_corpus.len();
-        if corpus_size == 0 {
+        if tokenized.is_empty() {
             return Err(PyErr::new::<PyValueError, _>(
                 "Corpus size must be greater than zero.",
             ));
         }
 
-        // Initialize with optimized structures
-        let (nd, doc_freqs, doc_len, avgdl) = Self::initialize_optimized(tokenized_corpus, &mut interner);
-        let idf_map = Self::calc_idf_optimized(nd, corpus_size);
+        let mut interner = StringInterner::default();
+        let built = py.allow_threads(|| build_index(tokenized, &mut interner));
+        let idf_map = py.allow_threads(|| calc_idf_l(built.nd, built.corpus_size));
 
-        // Precompute values
         let k1_plus1 = k1 + 1.0;
         let one_minus_b = 1.0 - b;
-        let b_over_avgdl = b / avgdl;
+        let b_over_avgdl = b / built.avgdl;
 
         Ok(BM25L {
             k1,
             b,
             delta,
-            corpus_size,
-            avgdl,
-            doc_freqs: Arc::new(doc_freqs),
+            corpus_size: built.corpus_size,
+            avgdl: built.avgdl,
+            doc_freqs: Arc::new(built.doc_freqs),
+            doc_len: Arc::new(built.doc_len),
+            inverted: Arc::new(built.inverted),
             idf: Arc::new(idf_map),
-            doc_len: Arc::new(doc_len),
             interner: Arc::new(interner),
             tokenizer,
             k1_plus1,
@@ -97,73 +140,100 @@ impl BM25L {
         })
     }
 
-    /// Calculates BM25L scores for a given query - optimized version
-    pub fn get_scores(&self, query: Vec<String>) -> PyResult<Vec<f64>> {
+    pub fn preprocess_query(&self, query: Vec<String>) -> PyResult<crate::bm25okapi::PyPreprocessedQuery> {
+        Ok(crate::bm25okapi::PyPreprocessedQuery::from_inner(self.preprocess(&query)))
+    }
+
+    pub fn get_scores(&self, py: Python, query: Vec<String>) -> PyResult<Vec<f64>> {
         if self.corpus_size == 0 {
             return Ok(vec![]);
         }
 
-        // Convert query terms to symbols
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; self.corpus_size]);
         }
 
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; self.corpus_size]);
-        }
-
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-        let delta = self.delta;
-
-        let scores: Vec<f64> = (0..self.corpus_size)
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let denominator = one_minus_b + b_over_avgdl * dl;
-
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let ctd = if denominator > 0.0 {
-                            freq_f64 / denominator
-                        } else {
-                            0.0
-                        };
-                        let numerator = k1_plus1 * (ctd + delta);
-                        let denom = k1 + ctd + delta;
-                        if denom > 0.0 {
-                            score + idf_val * numerator / denom
-                        } else {
-                            score
-                        }
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
-
-        Ok(scores)
+        py.allow_threads(|| Ok(score_all_inverted(&view, &preprocessed, params, formula)))
     }
 
-    /// Calculates BM25 scores for a batch of documents given a query - optimized version
-    pub fn get_batch_scores(&self, query: Vec<String>, doc_ids: Vec<usize>) -> PyResult<Vec<f64>> {
+    #[cfg(feature = "numpy")]
+    pub fn get_scores_numpy<'py>(
+        &self,
+        py: Python<'py>,
+        query: Vec<String>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let scores = self.get_scores(py, query)?;
+        Ok(PyArray1::from_vec_bound(py, scores))
+    }
+
+    #[pyo3(signature = (query, documents, n=None))]
+    pub fn get_top_n(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        documents: Vec<String>,
+        n: Option<usize>,
+    ) -> PyResult<Vec<(String, f64)>> {
+        let n = n.unwrap_or(5);
+        if self.corpus_size != documents.len() {
+            return Err(PyErr::new::<PyValueError, _>(
+                "The documents given don't match the index corpus!",
+            ));
+        }
+
+        let top = self.get_top_n_indices(py, query, Some(n))?;
+        Ok(top
+            .into_iter()
+            .map(|(i, score)| (documents[i].clone(), score))
+            .collect())
+    }
+
+    #[pyo3(signature = (query, n=None))]
+    pub fn get_top_n_indices(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        n: Option<usize>,
+    ) -> PyResult<Vec<(usize, f64)>> {
+        let n = n.unwrap_or(5);
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
+            return Ok((0..self.corpus_size.min(n))
+                .map(|i| (i, 0.0))
+                .collect());
+        }
+
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
+
+        py.allow_threads(|| {
+            Ok(top_k_inverted(&view, &preprocessed, params, formula, n))
+        })
+    }
+
+    #[pyo3(signature = (query, chunk_size=None))]
+    pub fn get_scores_chunked(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        chunk_size: Option<usize>,
+    ) -> PyResult<Vec<f64>> {
+        let _chunk_size = chunk_size.unwrap_or(1000);
+        self.get_scores(py, query)
+    }
+
+    pub fn get_batch_scores(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        doc_ids: Vec<usize>,
+    ) -> PyResult<Vec<f64>> {
         if doc_ids.is_empty() {
             return Ok(vec![]);
         }
@@ -174,187 +244,46 @@ impl BM25L {
             ));
         }
 
-        // Convert query terms to symbols
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; doc_ids.len()]);
         }
 
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let doc_freqs = Arc::clone(&self.doc_freqs);
+        let doc_len = Arc::clone(&self.doc_len);
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; doc_ids.len()]);
-        }
-
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-        let delta = self.delta;
-
-        let scores: Vec<f64> = doc_ids
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let denominator = one_minus_b + b_over_avgdl * dl;
-
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let ctd = if denominator > 0.0 {
-                            freq_f64 / denominator
-                        } else {
-                            0.0
-                        };
-                        let numerator = k1_plus1 * (ctd + delta);
-                        let denom = k1 + ctd + delta;
-                        if denom > 0.0 {
-                            score + idf_val * numerator / denom
-                        } else {
-                            score
-                        }
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
-
-        Ok(scores)
+        py.allow_threads(|| {
+            Ok(score_documents_parallel(
+                &doc_ids,
+                &doc_freqs,
+                &doc_len,
+                &preprocessed,
+                params,
+                formula,
+            ))
+        })
     }
 
-    /// Retrieves the top N documents with their scores
-    pub fn get_top_n(
+    pub fn get_scores_batch(
         &self,
-        query: Vec<String>,
-        documents: Vec<String>,
-        n: usize,
-    ) -> PyResult<Vec<(String, f64)>> {
-        if self.corpus_size != documents.len() {
-            return Err(PyErr::new::<PyValueError, _>(
-                "The documents given don't match the index corpus!",
-            ));
-        }
-
-        let scores = self.get_scores(query)?;
-        let mut doc_scores: Vec<(String, f64)> =
-            documents.into_iter().zip(scores.into_iter()).collect();
-
-        doc_scores.par_sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-
-        let top_n: Vec<(String, f64)> = doc_scores.into_iter().take(n).collect();
-
-        Ok(top_n)
-    }
-}
-
-impl BM25L {
-    /// Tokenizes the corpus using the provided tokenizer
-    fn tokenize_corpus_with_py(
         py: Python,
-        corpus: &[String],
-        tokenizer_py: &Py<PyAny>,
-    ) -> PyResult<Vec<SmallVec<[String; 16]>>> {
-        let mut tokenized_corpus = Vec::with_capacity(corpus.len());
-        for doc in corpus {
-            let tokens: Vec<String> = tokenizer_py
-                .call1(py, (doc,))
-                .map_err(|e| PyValueError::new_err(format!("Tokenizer failed: {}", e)))?
-                .extract(py)
-                .map_err(|e| PyValueError::new_err(format!("Failed to extract tokens: {}", e)))?;
-            tokenized_corpus.push(SmallVec::from_vec(tokens));
+        queries: Vec<Vec<String>>,
+    ) -> PyResult<Vec<Vec<f64>>> {
+        if self.corpus_size == 0 {
+            return Ok(vec![]);
         }
 
-        Ok(tokenized_corpus)
-    }
+        let preprocessed: Vec<PreprocessedQuery> =
+            queries.iter().map(|q| self.preprocess(q)).collect();
 
-    /// Optimized initialization with string interning
-    fn initialize_optimized(
-        corpus: Vec<SmallVec<[String; 16]>>,
-        interner: &mut StringInterner<DefaultBackend>,
-    ) -> (
-        AHashMap<DefaultSymbol, u32>,
-        Vec<AHashMap<DefaultSymbol, u32>>,
-        Vec<u32>,
-        f64,
-    ) {
-        let corpus_size = corpus.len();
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        // Pre-intern all unique terms
-        let mut all_terms = std::collections::HashSet::new();
-        for doc in &corpus {
-            for term in doc {
-                all_terms.insert(term.as_str());
-            }
-        }
-
-        let _: Vec<_> = all_terms.iter().map(|term| interner.get_or_intern(term)).collect();
-
-        // Process documents in parallel
-        let doc_data: Vec<(AHashMap<DefaultSymbol, u32>, u32, std::collections::HashSet<DefaultSymbol>)> = corpus
-            .into_par_iter()
-            .map(|doc| {
-                let mut freq_map = AHashMap::with_capacity(doc.len().min(64));
-                let mut unique_terms = std::collections::HashSet::with_capacity(doc.len().min(64));
-                
-                for term in &doc {
-                    if let Some(symbol) = interner.get(term) {
-                        *freq_map.entry(symbol).or_insert(0) += 1;
-                        unique_terms.insert(symbol);
-                    }
-                }
-                
-                (freq_map, doc.len() as u32, unique_terms)
-            })
-            .collect();
-
-        // Collect results
-        let mut doc_freqs = Vec::with_capacity(corpus_size);
-        let mut doc_len = Vec::with_capacity(corpus_size);
-        let mut total_len = 0u64;
-
-        for (freq_map, len, _) in &doc_data {
-            doc_freqs.push(freq_map.clone());
-            doc_len.push(*len);
-            total_len += *len as u64;
-        }
-
-        let avgdl = total_len as f64 / corpus_size as f64;
-
-        // Compute document frequencies
-        let mut nd = AHashMap::new();
-        for (_, _, unique_terms) in &doc_data {
-            for &symbol in unique_terms {
-                *nd.entry(symbol).or_insert(0) += 1;
-            }
-        }
-
-        (nd, doc_freqs, doc_len, avgdl)
-    }
-
-    /// Optimized IDF calculation for BM25L
-    fn calc_idf_optimized(
-        nd: AHashMap<DefaultSymbol, u32>,
-        corpus_size: usize,
-    ) -> AHashMap<DefaultSymbol, f64> {
-        let corpus_size_f64 = corpus_size as f64;
-
-        nd.into_iter()
-            .map(|(symbol, freq)| {
-                let freq_f64 = freq as f64;
-                let idf_val = (corpus_size_f64 + 1.0).ln() - (freq_f64 + 0.5).ln();
-                (symbol, idf_val)
-            })
-            .collect()
+        py.allow_threads(|| {
+            Ok(score_queries_batch(&view, &preprocessed, params, formula))
+        })
     }
 }

--- a/src/bm25okapi.rs
+++ b/src/bm25okapi.rs
@@ -1,10 +1,19 @@
-use ahash::{AHashMap, AHashSet};
+use crate::index::{
+    build_index, calc_idf_okapi, tokenize_corpus_parallel, tokenize_corpus_with_py,
+    tokenized_corpus_from_vecs, IndexView,
+};
+use crate::scoring::{
+    preprocess_query, score_all_inverted, score_documents_parallel, score_queries_batch,
+    top_k_inverted, PreprocessedQuery, ScoreFormula, ScoreParams,
+};
+use ahash::AHashMap;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use rayon::prelude::*;
-use smallvec::SmallVec;
 use std::sync::Arc;
 use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
+
+#[cfg(feature = "numpy")]
+use numpy::PyArray1;
 
 /// BM25Okapi structure with necessary fields - optimized version
 #[pyclass]
@@ -19,26 +28,55 @@ pub struct BM25Okapi {
     corpus_size: usize,
     #[pyo3(get)]
     avgdl: f64,
-    // Optimized data structures
-    doc_freqs: Arc<Vec<AHashMap<DefaultSymbol, u32>>>, // Use symbols and u32 for better cache performance
-    idf: Arc<AHashMap<DefaultSymbol, f64>>,            // Use AHashMap for better performance
-    doc_len: Arc<Vec<u32>>, // Use u32 instead of usize for better cache performance
-    interner: Arc<StringInterner<DefaultBackend>>, // String interner for vocabulary
-    tokenizer: Option<Py<PyAny>>, // Optional Python tokenizer
-    // Precomputed values for faster scoring
+    doc_freqs: Arc<Vec<AHashMap<DefaultSymbol, u32>>>,
+    idf: Arc<AHashMap<DefaultSymbol, f64>>,
+    doc_len: Arc<Vec<u32>>,
+    inverted: Arc<AHashMap<DefaultSymbol, Vec<(u32, u32)>>>,
+    interner: Arc<StringInterner<DefaultBackend>>,
+    tokenizer: Option<Py<PyAny>>,
     k1_plus1: f64,
     one_minus_b: f64,
     b_over_avgdl: f64,
 }
 
+impl BM25Okapi {
+    fn score_params(&self) -> ScoreParams {
+        ScoreParams {
+            k1: self.k1,
+            k1_plus1: self.k1_plus1,
+            one_minus_b: self.one_minus_b,
+            b_over_avgdl: self.b_over_avgdl,
+        }
+    }
+
+    fn formula(&self) -> ScoreFormula {
+        ScoreFormula::Okapi
+    }
+
+    fn preprocess(&self, query: &[String]) -> PreprocessedQuery {
+        preprocess_query(query, &self.interner, &self.idf)
+    }
+
+    fn index_view(&self) -> IndexView<'_> {
+        IndexView {
+            doc_freqs: &self.doc_freqs,
+            doc_len: &self.doc_len,
+            inverted: &self.inverted,
+            corpus_size: self.corpus_size,
+            avgdl: self.avgdl,
+        }
+    }
+}
+
 #[pymethods]
 impl BM25Okapi {
     #[new]
-    #[pyo3(signature = (corpus, tokenizer=None, k1=None, b=None, epsilon=None))]
+    #[pyo3(signature = (corpus=None, tokenizer=None, tokenized_corpus=None, k1=None, b=None, epsilon=None))]
     pub fn new(
         py: Python,
-        corpus: Vec<String>,
+        corpus: Option<Vec<String>>,
         tokenizer: Option<Bound<PyAny>>,
+        tokenized_corpus: Option<Vec<Vec<String>>>,
         k1: Option<f64>,
         b: Option<f64>,
         epsilon: Option<f64>,
@@ -48,52 +86,52 @@ impl BM25Okapi {
         let epsilon = epsilon.unwrap_or(0.25);
 
         let tokenizer = tokenizer.map(|tk| tk.into());
-        let mut interner = StringInterner::default();
 
-        // Tokenize the corpus
-        let tokenized_corpus = if let Some(ref tokenizer_py) = tokenizer {
-            // Sequential tokenization due to GIL
-            Self::tokenize_corpus_with_py(py, &corpus, tokenizer_py)?
-        } else {
-            // Optimized parallel tokenization with string interning
-            corpus
-                .par_iter()
-                .map(|doc| {
-                    doc.split_whitespace()
-                        .map(|s| s.to_lowercase())
-                        .collect::<SmallVec<[String; 16]>>() // Use SmallVec for better performance on small docs
-                })
-                .collect()
+        let tokenized = match (corpus, tokenized_corpus) {
+            (Some(corpus_docs), None) => {
+                if let Some(ref tokenizer_py) = tokenizer {
+                    tokenize_corpus_with_py(py, &corpus_docs, tokenizer_py)?
+                } else {
+                    py.allow_threads(|| tokenize_corpus_parallel(&corpus_docs))
+                }
+            }
+            (None, Some(tokens)) => tokenized_corpus_from_vecs(tokens),
+            (Some(_), Some(_)) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Provide either corpus or tokenized_corpus, not both.",
+                ));
+            }
+            (None, None) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Either corpus or tokenized_corpus must be provided.",
+                ));
+            }
         };
 
-        let corpus_size = tokenized_corpus.len();
-        if corpus_size == 0 {
+        if tokenized.is_empty() {
             return Err(PyErr::new::<PyValueError, _>(
                 "Corpus size must be greater than zero.",
             ));
         }
 
-        // Initialize structures with optimized data types
-        let (nd, doc_freqs, doc_len, avgdl) =
-            Self::initialize_optimized(tokenized_corpus, &mut interner);
+        let mut interner = StringInterner::default();
+        let built = py.allow_threads(|| build_index(tokenized, &mut interner));
+        let idf_map = py.allow_threads(|| calc_idf_okapi(built.nd, built.corpus_size, epsilon));
 
-        // Calculate IDF with optimized algorithm
-        let idf_map = Self::calc_idf_optimized(nd, corpus_size, epsilon);
-
-        // Precompute frequently used values
         let k1_plus1 = k1 + 1.0;
         let one_minus_b = 1.0 - b;
-        let b_over_avgdl = b / avgdl;
+        let b_over_avgdl = b / built.avgdl;
 
         Ok(BM25Okapi {
             k1,
             b,
             epsilon,
-            corpus_size,
-            avgdl,
-            doc_freqs: Arc::new(doc_freqs),
+            corpus_size: built.corpus_size,
+            avgdl: built.avgdl,
+            doc_freqs: Arc::new(built.doc_freqs),
+            doc_len: Arc::new(built.doc_len),
+            inverted: Arc::new(built.inverted),
             idf: Arc::new(idf_map),
-            doc_len: Arc::new(doc_len),
             interner: Arc::new(interner),
             tokenizer,
             k1_plus1,
@@ -102,67 +140,45 @@ impl BM25Okapi {
         })
     }
 
-    /// Calculates BM25 scores for all documents given a query - optimized version
-    pub fn get_scores(&self, query: Vec<String>) -> PyResult<Vec<f64>> {
+    /// Preprocess a query for reuse across multiple scoring calls.
+    pub fn preprocess_query(&self, query: Vec<String>) -> PyResult<PyPreprocessedQuery> {
+        Ok(PyPreprocessedQuery::from_inner(self.preprocess(&query)))
+    }
+
+    /// Calculates BM25 scores for all documents given a query.
+    pub fn get_scores(&self, py: Python, query: Vec<String>) -> PyResult<Vec<f64>> {
         if self.corpus_size == 0 {
             return Ok(vec![]);
         }
 
-        // Convert query terms to symbols for faster lookup
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; self.corpus_size]);
         }
 
-        // Precompute query term IDFs - use symbols for faster lookup
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; self.corpus_size]);
-        }
-
-        // Use precomputed values for better performance
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-
-        // Compute scores in parallel with optimized algorithm
-        let scores: Vec<f64> = (0..self.corpus_size)
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let norm_factor = k1 * (one_minus_b + b_over_avgdl * dl);
-
-                // Use fold with early termination for better performance
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let numerator = freq_f64 * k1_plus1;
-                        let denominator = freq_f64 + norm_factor;
-                        score + idf_val * (numerator / denominator)
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
-
-        Ok(scores)
+        py.allow_threads(|| Ok(score_all_inverted(&view, &preprocessed, params, formula)))
     }
 
-    /// Retrieves the top N documents for a given query, along with their scores
+    /// NumPy array variant of get_scores.
+    #[cfg(feature = "numpy")]
+    pub fn get_scores_numpy<'py>(
+        &self,
+        py: Python<'py>,
+        query: Vec<String>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let scores = self.get_scores(py, query)?;
+        Ok(PyArray1::from_vec_bound(py, scores))
+    }
+
+    /// Retrieves the top N documents for a given query, along with their scores.
     #[pyo3(signature = (query, documents, n=None))]
     pub fn get_top_n(
         &self,
+        py: Python,
         query: Vec<String>,
         documents: Vec<String>,
         n: Option<usize>,
@@ -174,104 +190,63 @@ impl BM25Okapi {
             ));
         }
 
-        let scores = self.get_scores(query)?;
-
-        // Use optimized top-k selection for better performance
-        let top_indices = crate::optimizations::select_top_k_indices(&scores, n);
-
-        let top_n: Vec<(String, f64)> = top_indices
+        let top = self.get_top_n_indices(py, query, Some(n))?;
+        Ok(top
             .into_iter()
-            .map(|i| (documents[i].clone(), scores[i]))
-            .collect();
-
-        Ok(top_n)
+            .map(|(i, score)| (documents[i].clone(), score))
+            .collect())
     }
 
-    /// Optimized method to get only top N document indices (faster when you don't need the full documents)
+    /// Optimized method to get only top N document indices.
     #[pyo3(signature = (query, n=None))]
     pub fn get_top_n_indices(
         &self,
+        py: Python,
         query: Vec<String>,
         n: Option<usize>,
     ) -> PyResult<Vec<(usize, f64)>> {
         let n = n.unwrap_or(5);
-        let scores = self.get_scores(query)?;
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
+            return Ok((0..self.corpus_size.min(n))
+                .map(|i| (i, 0.0))
+                .collect());
+        }
 
-        let top_indices = crate::optimizations::select_top_k_indices(&scores, n);
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        let result: Vec<(usize, f64)> = top_indices.into_iter().map(|i| (i, scores[i])).collect();
-
-        Ok(result)
+        py.allow_threads(|| {
+            Ok(top_k_inverted(
+                &view,
+                &preprocessed,
+                params,
+                formula,
+                n,
+            ))
+        })
     }
 
-    /// Batch scoring with chunked processing for better cache performance
+    /// Batch scoring with chunked processing (uses inverted-index scoring).
     #[pyo3(signature = (query, chunk_size=None))]
     pub fn get_scores_chunked(
         &self,
+        py: Python,
         query: Vec<String>,
         chunk_size: Option<usize>,
     ) -> PyResult<Vec<f64>> {
-        let chunk_size = chunk_size.unwrap_or(1000);
-
-        if self.corpus_size == 0 {
-            return Ok(vec![]);
-        }
-
-        // Convert query terms to symbols for faster lookup
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
-            return Ok(vec![0.0; self.corpus_size]);
-        }
-
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
-
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; self.corpus_size]);
-        }
-
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-
-        // Process in chunks for better cache performance
-        let scores = crate::optimizations::process_documents_in_chunks(
-            self.corpus_size,
-            chunk_size,
-            |start, end| {
-                (start..end)
-                    .into_par_iter()
-                    .map(|i| {
-                        let doc_freq = &self.doc_freqs[i];
-                        let dl = self.doc_len[i] as f64;
-                        let norm_factor = k1 * (one_minus_b + b_over_avgdl * dl);
-
-                        crate::optimizations::compute_bm25_score_vectorized(
-                            &query_terms,
-                            doc_freq,
-                            dl,
-                            norm_factor,
-                            k1_plus1,
-                        )
-                    })
-                    .collect()
-            },
-        );
-
-        Ok(scores)
+        let _chunk_size = chunk_size.unwrap_or(1000);
+        self.get_scores(py, query)
     }
 
-    /// Calculates BM25 scores for a batch of documents given a query - optimized version
-    pub fn get_batch_scores(&self, query: Vec<String>, doc_ids: Vec<usize>) -> PyResult<Vec<f64>> {
+    /// Calculates BM25 scores for a batch of documents given a query.
+    pub fn get_batch_scores(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        doc_ids: Vec<usize>,
+    ) -> PyResult<Vec<f64>> {
         if doc_ids.is_empty() {
             return Ok(vec![]);
         }
@@ -282,178 +257,98 @@ impl BM25Okapi {
             ));
         }
 
-        // Convert query terms to symbols for faster lookup
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; doc_ids.len()]);
         }
 
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let doc_freqs = Arc::clone(&self.doc_freqs);
+        let doc_len = Arc::clone(&self.doc_len);
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; doc_ids.len()]);
+        py.allow_threads(|| {
+            Ok(score_documents_parallel(
+                &doc_ids,
+                &doc_freqs,
+                &doc_len,
+                &preprocessed,
+                params,
+                formula,
+            ))
+        })
+    }
+
+    /// Score multiple queries in one call.
+    pub fn get_scores_batch(
+        &self,
+        py: Python,
+        queries: Vec<Vec<String>>,
+    ) -> PyResult<Vec<Vec<f64>>> {
+        if self.corpus_size == 0 {
+            return Ok(vec![]);
         }
 
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
+        let preprocessed: Vec<PreprocessedQuery> =
+            queries.iter().map(|q| self.preprocess(q)).collect();
 
-        // Compute scores in parallel with optimized algorithm
-        let scores: Vec<f64> = doc_ids
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let norm_factor = k1 * (one_minus_b + b_over_avgdl * dl);
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let numerator = freq_f64 * k1_plus1;
-                        let denominator = freq_f64 + norm_factor;
-                        score + idf_val * (numerator / denominator)
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
+        py.allow_threads(|| {
+            Ok(score_queries_batch(
+                &view,
+                &preprocessed,
+                params,
+                formula,
+            ))
+        })
+    }
 
-        Ok(scores)
+    /// Score documents using a preprocessed query handle.
+    pub fn get_scores_with_preprocessed(
+        &self,
+        py: Python,
+        preprocessed: &PyPreprocessedQuery,
+    ) -> PyResult<Vec<f64>> {
+        if self.corpus_size == 0 {
+            return Ok(vec![]);
+        }
+        if preprocessed.inner.is_empty() {
+            return Ok(vec![0.0; self.corpus_size]);
+        }
+
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
+
+        py.allow_threads(|| {
+            Ok(score_all_inverted(
+                &view,
+                &preprocessed.inner,
+                params,
+                formula,
+            ))
+        })
     }
 }
 
-impl BM25Okapi {
-    /// Tokenizes the corpus using the provided tokenizer
-    fn tokenize_corpus_with_py(
-        py: Python,
-        corpus: &[String],
-        tokenizer_py: &Py<PyAny>,
-    ) -> PyResult<Vec<SmallVec<[String; 16]>>> {
-        // Sequential tokenization due to GIL requirements
-        let mut tokenized_corpus = Vec::with_capacity(corpus.len());
-        for doc in corpus {
-            let tokens: Vec<String> = tokenizer_py
-                .call1(py, (doc,))
-                .map_err(|e| PyValueError::new_err(format!("Tokenizer failed: {}", e)))?
-                .extract(py)
-                .map_err(|e| PyValueError::new_err(format!("Failed to extract tokens: {}", e)))?;
-            tokenized_corpus.push(SmallVec::from_vec(tokens));
-        }
+/// Python-visible handle for a preprocessed query.
+#[pyclass]
+pub struct PyPreprocessedQuery {
+    inner: PreprocessedQuery,
+}
 
-        Ok(tokenized_corpus)
+impl PyPreprocessedQuery {
+    pub(crate) fn from_inner(inner: PreprocessedQuery) -> Self {
+        Self { inner }
     }
+}
 
-    /// Optimized initialization with string interning and better data structures
-    fn initialize_optimized(
-        corpus: Vec<SmallVec<[String; 16]>>,
-        interner: &mut StringInterner<DefaultBackend>,
-    ) -> (
-        AHashMap<DefaultSymbol, u32>,      // nd
-        Vec<AHashMap<DefaultSymbol, u32>>, // doc_freqs
-        Vec<u32>,                          // doc_len
-        f64,                               // avgdl
-    ) {
-        let corpus_size = corpus.len();
-
-        // Pre-intern all unique terms for better memory efficiency
-        let mut all_terms = AHashSet::new();
-        for doc in &corpus {
-            for term in doc {
-                all_terms.insert(term.as_str());
-            }
-        }
-
-        // Intern all terms at once
-        let _: Vec<_> = all_terms
-            .iter()
-            .map(|term| interner.get_or_intern(term))
-            .collect();
-
-        // Calculate document lengths and frequencies in parallel with optimized data structures
-        let doc_data: Vec<(AHashMap<DefaultSymbol, u32>, u32, AHashSet<DefaultSymbol>)> = corpus
-            .into_par_iter()
-            .map(|doc| {
-                let mut freq_map = AHashMap::with_capacity(doc.len().min(64)); // Reasonable initial capacity
-                let mut unique_terms = AHashSet::with_capacity(doc.len().min(64));
-
-                for term in &doc {
-                    // This is safe because we pre-interned all terms
-                    if let Some(symbol) = interner.get(term) {
-                        *freq_map.entry(symbol).or_insert(0) += 1;
-                        unique_terms.insert(symbol);
-                    }
-                }
-
-                (freq_map, doc.len() as u32, unique_terms)
-            })
-            .collect();
-
-        // Collect doc_freqs and doc_len with better memory layout
-        let mut doc_freqs = Vec::with_capacity(corpus_size);
-        let mut doc_len = Vec::with_capacity(corpus_size);
-        let mut total_len = 0u64;
-
-        for (freq_map, len, _) in &doc_data {
-            doc_freqs.push(freq_map.clone());
-            doc_len.push(*len);
-            total_len += *len as u64;
-        }
-
-        let avgdl = total_len as f64 / corpus_size as f64;
-
-        // Compute nd (document frequencies) more efficiently
-        let mut nd = AHashMap::new();
-        for (_, _, unique_terms) in &doc_data {
-            for &symbol in unique_terms {
-                *nd.entry(symbol).or_insert(0) += 1;
-            }
-        }
-
-        (nd, doc_freqs, doc_len, avgdl)
-    }
-
-    /// Optimized IDF calculation with better numerical stability
-    fn calc_idf_optimized(
-        nd: AHashMap<DefaultSymbol, u32>,
-        corpus_size: usize,
-        epsilon: f64,
-    ) -> AHashMap<DefaultSymbol, f64> {
-        let corpus_size_f64 = corpus_size as f64;
-
-        // Compute initial IDF values in parallel
-        let idf_values: Vec<(DefaultSymbol, f64)> = nd
-            .par_iter()
-            .map(|(&symbol, &doc_freq)| {
-                let doc_freq_f64 = doc_freq as f64;
-                // Use more numerically stable IDF calculation
-                let idf = ((corpus_size_f64 - doc_freq_f64 + 0.5) / (doc_freq_f64 + 0.5)).ln();
-                (symbol, idf)
-            })
-            .collect();
-
-        // Compute average IDF for negative adjustment
-        let idf_sum: f64 = idf_values.par_iter().map(|(_, idf)| *idf).sum();
-        let average_idf = idf_sum / idf_values.len() as f64;
-        let eps = epsilon * average_idf;
-
-        // Adjust negative IDFs and collect into AHashMap
-        idf_values
-            .into_iter()
-            .map(|(symbol, idf)| {
-                let adjusted_idf = if idf < 0.0 { eps } else { idf };
-                (symbol, adjusted_idf)
-            })
-            .collect()
+#[pymethods]
+impl PyPreprocessedQuery {
+    fn __len__(&self) -> usize {
+        self.inner.len()
     }
 }

--- a/src/bm25plus.rs
+++ b/src/bm25plus.rs
@@ -1,10 +1,19 @@
+use crate::index::{
+    build_index, calc_idf_plus, tokenize_corpus_parallel, tokenize_corpus_with_py,
+    tokenized_corpus_from_vecs, IndexView,
+};
+use crate::scoring::{
+    preprocess_query, score_all_inverted, score_documents_parallel, score_queries_batch,
+    top_k_inverted, PreprocessedQuery, ScoreFormula, ScoreParams,
+};
+use ahash::AHashMap;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use rayon::prelude::*;
-use ahash::{AHashMap, AHashSet};
-use smallvec::SmallVec;
-use string_interner::{StringInterner, DefaultSymbol, DefaultBackend};
 use std::sync::Arc;
+use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
+
+#[cfg(feature = "numpy")]
+use numpy::PyArray1;
 
 /// BM25Plus structure with necessary fields - optimized version
 #[pyclass]
@@ -19,26 +28,55 @@ pub struct BM25Plus {
     corpus_size: usize,
     #[pyo3(get)]
     avgdl: f64,
-    // Optimized data structures
     doc_freqs: Arc<Vec<AHashMap<DefaultSymbol, u32>>>,
     idf: Arc<AHashMap<DefaultSymbol, f64>>,
     doc_len: Arc<Vec<u32>>,
+    inverted: Arc<AHashMap<DefaultSymbol, Vec<(u32, u32)>>>,
     interner: Arc<StringInterner<DefaultBackend>>,
     tokenizer: Option<Py<PyAny>>,
-    // Precomputed values
     k1_plus1: f64,
     one_minus_b: f64,
     b_over_avgdl: f64,
 }
 
+impl BM25Plus {
+    fn score_params(&self) -> ScoreParams {
+        ScoreParams {
+            k1: self.k1,
+            k1_plus1: self.k1_plus1,
+            one_minus_b: self.one_minus_b,
+            b_over_avgdl: self.b_over_avgdl,
+        }
+    }
+
+    fn formula(&self) -> ScoreFormula {
+        ScoreFormula::Plus { delta: self.delta }
+    }
+
+    fn preprocess(&self, query: &[String]) -> PreprocessedQuery {
+        preprocess_query(query, &self.interner, &self.idf)
+    }
+
+    fn index_view(&self) -> IndexView<'_> {
+        IndexView {
+            doc_freqs: &self.doc_freqs,
+            doc_len: &self.doc_len,
+            inverted: &self.inverted,
+            corpus_size: self.corpus_size,
+            avgdl: self.avgdl,
+        }
+    }
+}
+
 #[pymethods]
 impl BM25Plus {
     #[new]
-    #[pyo3(signature = (corpus, tokenizer=None, k1=None, b=None, delta=None))]
+    #[pyo3(signature = (corpus=None, tokenizer=None, tokenized_corpus=None, k1=None, b=None, delta=None))]
     pub fn new(
         py: Python,
-        corpus: Vec<String>,
+        corpus: Option<Vec<String>>,
         tokenizer: Option<Bound<PyAny>>,
+        tokenized_corpus: Option<Vec<Vec<String>>>,
         k1: Option<f64>,
         b: Option<f64>,
         delta: Option<f64>,
@@ -47,48 +85,53 @@ impl BM25Plus {
         let b = b.unwrap_or(0.75);
         let delta = delta.unwrap_or(1.0);
 
-        let tokenizer = tokenizer.map(|tokenizer| tokenizer.into());
-        let mut interner = StringInterner::default();
+        let tokenizer = tokenizer.map(|tk| tk.into());
 
-        // Tokenize corpus with optimization
-        let tokenized_corpus = if let Some(ref tokenizer_py) = tokenizer {
-            Self::tokenize_corpus_with_py(py, &corpus, tokenizer_py)?
-        } else {
-            corpus
-                .par_iter()
-                .map(|doc| {
-                    doc.split_whitespace()
-                        .map(|s| s.to_lowercase())
-                        .collect::<SmallVec<[String; 16]>>()
-                })
-                .collect()
+        let tokenized = match (corpus, tokenized_corpus) {
+            (Some(corpus_docs), None) => {
+                if let Some(ref tokenizer_py) = tokenizer {
+                    tokenize_corpus_with_py(py, &corpus_docs, tokenizer_py)?
+                } else {
+                    py.allow_threads(|| tokenize_corpus_parallel(&corpus_docs))
+                }
+            }
+            (None, Some(tokens)) => tokenized_corpus_from_vecs(tokens),
+            (Some(_), Some(_)) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Provide either corpus or tokenized_corpus, not both.",
+                ));
+            }
+            (None, None) => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    "Either corpus or tokenized_corpus must be provided.",
+                ));
+            }
         };
 
-        let corpus_size = tokenized_corpus.len();
-        if corpus_size == 0 {
+        if tokenized.is_empty() {
             return Err(PyErr::new::<PyValueError, _>(
                 "Corpus size must be greater than zero.",
             ));
         }
 
-        // Initialize with optimized structures
-        let (nd, doc_freqs, doc_len, avgdl) = Self::initialize_optimized(tokenized_corpus, &mut interner);
-        let idf_map = Self::calc_idf_optimized(nd, corpus_size);
+        let mut interner = StringInterner::default();
+        let built = py.allow_threads(|| build_index(tokenized, &mut interner));
+        let idf_map = py.allow_threads(|| calc_idf_plus(built.nd, built.corpus_size));
 
-        // Precompute values
         let k1_plus1 = k1 + 1.0;
         let one_minus_b = 1.0 - b;
-        let b_over_avgdl = b / avgdl;
+        let b_over_avgdl = b / built.avgdl;
 
         Ok(BM25Plus {
             k1,
             b,
             delta,
-            corpus_size,
-            avgdl,
-            doc_freqs: Arc::new(doc_freqs),
+            corpus_size: built.corpus_size,
+            avgdl: built.avgdl,
+            doc_freqs: Arc::new(built.doc_freqs),
+            doc_len: Arc::new(built.doc_len),
+            inverted: Arc::new(built.inverted),
             idf: Arc::new(idf_map),
-            doc_len: Arc::new(doc_len),
             interner: Arc::new(interner),
             tokenizer,
             k1_plus1,
@@ -97,64 +140,100 @@ impl BM25Plus {
         })
     }
 
-    /// Calculates BM25Plus scores for a given query - optimized version
-    pub fn get_scores(&self, query: Vec<String>) -> PyResult<Vec<f64>> {
+    pub fn preprocess_query(&self, query: Vec<String>) -> PyResult<crate::bm25okapi::PyPreprocessedQuery> {
+        Ok(crate::bm25okapi::PyPreprocessedQuery::from_inner(self.preprocess(&query)))
+    }
+
+    pub fn get_scores(&self, py: Python, query: Vec<String>) -> PyResult<Vec<f64>> {
         if self.corpus_size == 0 {
             return Ok(vec![]);
         }
 
-        // Convert query terms to symbols
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; self.corpus_size]);
         }
 
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; self.corpus_size]);
-        }
-
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-        let delta = self.delta;
-
-        let scores: Vec<f64> = (0..self.corpus_size)
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let norm_factor = k1 * (one_minus_b + b_over_avgdl * dl);
-
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let numerator = delta + freq_f64 * k1_plus1;
-                        let denominator = norm_factor + freq_f64;
-                        score + idf_val * (numerator / denominator)
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
-
-        Ok(scores)
+        py.allow_threads(|| Ok(score_all_inverted(&view, &preprocessed, params, formula)))
     }
 
-    /// Calculates BM25 scores for a batch of documents given a query - optimized version
-    pub fn get_batch_scores(&self, query: Vec<String>, doc_ids: Vec<usize>) -> PyResult<Vec<f64>> {
+    #[cfg(feature = "numpy")]
+    pub fn get_scores_numpy<'py>(
+        &self,
+        py: Python<'py>,
+        query: Vec<String>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let scores = self.get_scores(py, query)?;
+        Ok(PyArray1::from_vec_bound(py, scores))
+    }
+
+    #[pyo3(signature = (query, documents, n=None))]
+    pub fn get_top_n(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        documents: Vec<String>,
+        n: Option<usize>,
+    ) -> PyResult<Vec<(String, f64)>> {
+        let n = n.unwrap_or(5);
+        if self.corpus_size != documents.len() {
+            return Err(PyErr::new::<PyValueError, _>(
+                "The documents given don't match the index corpus!",
+            ));
+        }
+
+        let top = self.get_top_n_indices(py, query, Some(n))?;
+        Ok(top
+            .into_iter()
+            .map(|(i, score)| (documents[i].clone(), score))
+            .collect())
+    }
+
+    #[pyo3(signature = (query, n=None))]
+    pub fn get_top_n_indices(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        n: Option<usize>,
+    ) -> PyResult<Vec<(usize, f64)>> {
+        let n = n.unwrap_or(5);
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
+            return Ok((0..self.corpus_size.min(n))
+                .map(|i| (i, 0.0))
+                .collect());
+        }
+
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
+
+        py.allow_threads(|| {
+            Ok(top_k_inverted(&view, &preprocessed, params, formula, n))
+        })
+    }
+
+    #[pyo3(signature = (query, chunk_size=None))]
+    pub fn get_scores_chunked(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        chunk_size: Option<usize>,
+    ) -> PyResult<Vec<f64>> {
+        let _chunk_size = chunk_size.unwrap_or(1000);
+        self.get_scores(py, query)
+    }
+
+    pub fn get_batch_scores(
+        &self,
+        py: Python,
+        query: Vec<String>,
+        doc_ids: Vec<usize>,
+    ) -> PyResult<Vec<f64>> {
         if doc_ids.is_empty() {
             return Ok(vec![]);
         }
@@ -165,178 +244,46 @@ impl BM25Plus {
             ));
         }
 
-        // Convert query terms to symbols
-        let query_symbols: SmallVec<[DefaultSymbol; 8]> = query
-            .iter()
-            .filter_map(|term| self.interner.get(term))
-            .collect();
-
-        if query_symbols.is_empty() {
+        let preprocessed = self.preprocess(&query);
+        if preprocessed.is_empty() {
             return Ok(vec![0.0; doc_ids.len()]);
         }
 
-        // Precompute query term IDFs
-        let query_terms: SmallVec<[(DefaultSymbol, f64); 8]> = query_symbols
-            .iter()
-            .filter_map(|&symbol| self.idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
-            .collect();
+        let doc_freqs = Arc::clone(&self.doc_freqs);
+        let doc_len = Arc::clone(&self.doc_len);
+        let params = self.score_params();
+        let formula = self.formula();
 
-        if query_terms.is_empty() {
-            return Ok(vec![0.0; doc_ids.len()]);
-        }
-
-        // Use precomputed values
-        let k1_plus1 = self.k1_plus1;
-        let one_minus_b = self.one_minus_b;
-        let b_over_avgdl = self.b_over_avgdl;
-        let k1 = self.k1;
-        let delta = self.delta;
-
-        let scores: Vec<f64> = doc_ids
-            .into_par_iter()
-            .map(|i| {
-                let doc_freq = &self.doc_freqs[i];
-                let dl = self.doc_len[i] as f64;
-                let norm_factor = k1 * (one_minus_b + b_over_avgdl * dl);
-
-                query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                    if let Some(&freq) = doc_freq.get(&symbol) {
-                        let freq_f64 = freq as f64;
-                        let numerator = delta + freq_f64 * k1_plus1;
-                        let denominator = norm_factor + freq_f64;
-                        score + idf_val * (numerator / denominator)
-                    } else {
-                        score
-                    }
-                })
-            })
-            .collect();
-
-        Ok(scores)
+        py.allow_threads(|| {
+            Ok(score_documents_parallel(
+                &doc_ids,
+                &doc_freqs,
+                &doc_len,
+                &preprocessed,
+                params,
+                formula,
+            ))
+        })
     }
 
-    /// Retrieves the top N documents with their scores
-    pub fn get_top_n(
+    pub fn get_scores_batch(
         &self,
-        query: Vec<String>,
-        documents: Vec<String>,
-        n: usize,
-    ) -> PyResult<Vec<(String, f64)>> {
-        if self.corpus_size != documents.len() {
-            return Err(PyErr::new::<PyValueError, _>(
-                "The documents given don't match the index corpus!",
-            ));
-        }
-
-        let scores = self.get_scores(query)?;
-        let mut doc_scores: Vec<(String, f64)> =
-            documents.into_iter().zip(scores.into_iter()).collect();
-
-        doc_scores.par_sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-
-        let top_n: Vec<(String, f64)> = doc_scores.into_iter().take(n).collect();
-
-        Ok(top_n)
-    }
-}
-
-impl BM25Plus {
-    /// Tokenizes the corpus using the provided tokenizer
-    fn tokenize_corpus_with_py(
         py: Python,
-        corpus: &[String],
-        tokenizer_py: &Py<PyAny>,
-    ) -> PyResult<Vec<SmallVec<[String; 16]>>> {
-        let mut tokenized_corpus = Vec::with_capacity(corpus.len());
-        for doc in corpus {
-            let tokens: Vec<String> = tokenizer_py
-                .call1(py, (doc,))
-                .map_err(|e| PyValueError::new_err(format!("Tokenizer failed: {}", e)))?
-                .extract(py)
-                .map_err(|e| PyValueError::new_err(format!("Failed to extract tokens: {}", e)))?;
-            tokenized_corpus.push(SmallVec::from_vec(tokens));
+        queries: Vec<Vec<String>>,
+    ) -> PyResult<Vec<Vec<f64>>> {
+        if self.corpus_size == 0 {
+            return Ok(vec![]);
         }
 
-        Ok(tokenized_corpus)
-    }
+        let preprocessed: Vec<PreprocessedQuery> =
+            queries.iter().map(|q| self.preprocess(q)).collect();
 
-    /// Optimized initialization with string interning
-    fn initialize_optimized(
-        corpus: Vec<SmallVec<[String; 16]>>,
-        interner: &mut StringInterner<DefaultBackend>,
-    ) -> (
-        AHashMap<DefaultSymbol, u32>,
-        Vec<AHashMap<DefaultSymbol, u32>>,
-        Vec<u32>,
-        f64,
-    ) {
-        let corpus_size = corpus.len();
+        let view = self.index_view();
+        let params = self.score_params();
+        let formula = self.formula();
 
-        // Pre-intern all unique terms
-        let mut all_terms = AHashSet::new();
-        for doc in &corpus {
-            for term in doc {
-                all_terms.insert(term.as_str());
-            }
-        }
-
-        let _: Vec<_> = all_terms.iter().map(|term| interner.get_or_intern(term)).collect();
-
-        // Process documents in parallel
-        let doc_data: Vec<(AHashMap<DefaultSymbol, u32>, u32, AHashSet<DefaultSymbol>)> = corpus
-            .into_par_iter()
-            .map(|doc| {
-                let mut freq_map = AHashMap::with_capacity(doc.len().min(64));
-                let mut unique_terms = AHashSet::with_capacity(doc.len().min(64));
-                
-                for term in &doc {
-                    if let Some(symbol) = interner.get(term) {
-                        *freq_map.entry(symbol).or_insert(0) += 1;
-                        unique_terms.insert(symbol);
-                    }
-                }
-                
-                (freq_map, doc.len() as u32, unique_terms)
-            })
-            .collect();
-
-        // Collect results
-        let mut doc_freqs = Vec::with_capacity(corpus_size);
-        let mut doc_len = Vec::with_capacity(corpus_size);
-        let mut total_len = 0u64;
-
-        for (freq_map, len, _) in &doc_data {
-            doc_freqs.push(freq_map.clone());
-            doc_len.push(*len);
-            total_len += *len as u64;
-        }
-
-        let avgdl = total_len as f64 / corpus_size as f64;
-
-        // Compute document frequencies
-        let mut nd = AHashMap::new();
-        for (_, _, unique_terms) in &doc_data {
-            for &symbol in unique_terms {
-                *nd.entry(symbol).or_insert(0) += 1;
-            }
-        }
-
-        (nd, doc_freqs, doc_len, avgdl)
-    }
-
-    /// Optimized IDF calculation for BM25Plus
-    fn calc_idf_optimized(
-        nd: AHashMap<DefaultSymbol, u32>,
-        corpus_size: usize,
-    ) -> AHashMap<DefaultSymbol, f64> {
-        let corpus_size_f64 = corpus_size as f64;
-
-        nd.into_iter()
-            .map(|(symbol, freq)| {
-                let freq_f64 = freq as f64;
-                let idf_val = (corpus_size_f64 + 1.0).ln() - freq_f64.ln();
-                (symbol, idf_val)
-            })
-            .collect()
+        py.allow_threads(|| {
+            Ok(score_queries_batch(&view, &preprocessed, params, formula))
+        })
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,232 @@
+//! Shared corpus indexing: tokenization, document frequencies, and inverted index.
+
+use ahash::{AHashMap, AHashSet};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+use smallvec::SmallVec;
+use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
+
+/// Lowercase a token using an ASCII fast path when possible.
+pub fn lowercase_token(token: &str) -> String {
+    if token.bytes().all(|b| b.is_ascii()) {
+        token.to_ascii_lowercase()
+    } else {
+        token.to_lowercase()
+    }
+}
+
+/// Whitespace tokenize a document with lowercase tokens.
+pub fn tokenize_document(doc: &str) -> SmallVec<[String; 16]> {
+    doc.split_whitespace()
+        .map(lowercase_token)
+        .collect::<SmallVec<[String; 16]>>()
+}
+
+/// Tokenize a corpus in parallel (GIL must be released by caller).
+pub fn tokenize_corpus_parallel(corpus: &[String]) -> Vec<SmallVec<[String; 16]>> {
+    corpus
+        .par_iter()
+        .map(|doc| tokenize_document(doc))
+        .collect()
+}
+
+/// Tokenize using a Python callback (requires GIL).
+pub fn tokenize_corpus_with_py(
+    py: Python,
+    corpus: &[String],
+    tokenizer_py: &Py<PyAny>,
+) -> PyResult<Vec<SmallVec<[String; 16]>>> {
+    let mut tokenized_corpus = Vec::with_capacity(corpus.len());
+    for doc in corpus {
+        let tokens: Vec<String> = tokenizer_py
+            .call1(py, (doc,))
+            .map_err(|e| PyValueError::new_err(format!("Tokenizer failed: {e}")))?
+            .extract(py)
+            .map_err(|e| PyValueError::new_err(format!("Failed to extract tokens: {e}")))?;
+        tokenized_corpus.push(SmallVec::from_vec(tokens));
+    }
+    Ok(tokenized_corpus)
+}
+
+/// Convert pre-tokenized input from Python into SmallVec documents.
+pub fn tokenized_corpus_from_vecs(corpus: Vec<Vec<String>>) -> Vec<SmallVec<[String; 16]>> {
+    corpus
+        .into_iter()
+        .map(SmallVec::from_vec)
+        .collect()
+}
+
+/// Lightweight borrowed view of a built index for scoring.
+pub struct IndexView<'a> {
+    pub doc_freqs: &'a [AHashMap<DefaultSymbol, u32>],
+    pub doc_len: &'a [u32],
+    pub inverted: &'a AHashMap<DefaultSymbol, Vec<(u32, u32)>>,
+    pub corpus_size: usize,
+    pub avgdl: f64,
+}
+
+impl<'a> IndexView<'a> {
+    pub fn doc_len_f64(&self, doc_id: usize) -> f64 {
+        self.doc_len[doc_id] as f64
+    }
+}
+
+/// Built index structures shared by all BM25 variants.
+pub struct BuiltIndex {
+    pub doc_freqs: Vec<AHashMap<DefaultSymbol, u32>>,
+    pub doc_len: Vec<u32>,
+    pub inverted: AHashMap<DefaultSymbol, Vec<(u32, u32)>>,
+    pub nd: AHashMap<DefaultSymbol, u32>,
+    pub avgdl: f64,
+    pub corpus_size: usize,
+}
+
+/// Build document frequencies, inverted index, and document-frequency counts.
+pub fn build_index(
+    corpus: Vec<SmallVec<[String; 16]>>,
+    interner: &mut StringInterner<DefaultBackend>,
+) -> BuiltIndex {
+    let corpus_size = corpus.len();
+
+    let mut all_terms = AHashSet::new();
+    for doc in &corpus {
+        for term in doc {
+            all_terms.insert(term.as_str());
+        }
+    }
+
+    let _: Vec<_> = all_terms
+        .iter()
+        .map(|term| interner.get_or_intern(term))
+        .collect();
+
+    let doc_data: Vec<(AHashMap<DefaultSymbol, u32>, u32, AHashSet<DefaultSymbol>)> = corpus
+        .into_par_iter()
+        .map(|doc| {
+            let mut freq_map = AHashMap::with_capacity(doc.len().min(64));
+            let mut unique_terms = AHashSet::with_capacity(doc.len().min(64));
+
+            for term in &doc {
+                if let Some(symbol) = interner.get(term) {
+                    *freq_map.entry(symbol).or_insert(0) += 1;
+                    unique_terms.insert(symbol);
+                }
+            }
+
+            (freq_map, doc.len() as u32, unique_terms)
+        })
+        .collect();
+
+    let mut doc_freqs = Vec::with_capacity(corpus_size);
+    let mut doc_len = Vec::with_capacity(corpus_size);
+    let mut total_len = 0u64;
+
+    let nd: AHashMap<DefaultSymbol, u32> = doc_data
+        .par_iter()
+        .map(|(_, _, unique_terms)| {
+            let mut local = AHashMap::new();
+            for &symbol in unique_terms {
+                *local.entry(symbol).or_insert(0) += 1;
+            }
+            local
+        })
+        .reduce(
+            || AHashMap::new(),
+            |mut acc, local| {
+                for (symbol, count) in local {
+                    *acc.entry(symbol).or_insert(0) += count;
+                }
+                acc
+            },
+        );
+
+    for (freq_map, len, _) in doc_data {
+        total_len += len as u64;
+        doc_len.push(len);
+        doc_freqs.push(freq_map);
+    }
+
+    let avgdl = total_len as f64 / corpus_size as f64;
+
+    let mut inverted: AHashMap<DefaultSymbol, Vec<(u32, u32)>> = AHashMap::new();
+    for (doc_id, freq_map) in doc_freqs.iter().enumerate() {
+        for (&symbol, &freq) in freq_map {
+            inverted
+                .entry(symbol)
+                .or_default()
+                .push((doc_id as u32, freq));
+        }
+    }
+
+    BuiltIndex {
+        doc_freqs,
+        doc_len,
+        inverted,
+        nd,
+        avgdl,
+        corpus_size,
+    }
+}
+
+/// Robertson–Walker Okapi IDF with epsilon floor for negative values.
+pub fn calc_idf_okapi(
+    nd: AHashMap<DefaultSymbol, u32>,
+    corpus_size: usize,
+    epsilon: f64,
+) -> AHashMap<DefaultSymbol, f64> {
+    let corpus_size_f64 = corpus_size as f64;
+
+    let idf_values: Vec<(DefaultSymbol, f64)> = nd
+        .par_iter()
+        .map(|(&symbol, &doc_freq)| {
+            let doc_freq_f64 = doc_freq as f64;
+            let idf = ((corpus_size_f64 - doc_freq_f64 + 0.5) / (doc_freq_f64 + 0.5)).ln();
+            (symbol, idf)
+        })
+        .collect();
+
+    let idf_sum: f64 = idf_values.par_iter().map(|(_, idf)| *idf).sum();
+    let average_idf = idf_sum / idf_values.len() as f64;
+    let eps = epsilon * average_idf;
+
+    idf_values
+        .into_iter()
+        .map(|(symbol, idf)| {
+            let adjusted_idf = if idf < 0.0 { eps } else { idf };
+            (symbol, adjusted_idf)
+        })
+        .collect()
+}
+
+/// BM25Plus IDF.
+pub fn calc_idf_plus(
+    nd: AHashMap<DefaultSymbol, u32>,
+    corpus_size: usize,
+) -> AHashMap<DefaultSymbol, f64> {
+    let corpus_size_f64 = corpus_size as f64;
+
+    nd.into_iter()
+        .map(|(symbol, freq)| {
+            let freq_f64 = freq as f64;
+            let idf_val = (corpus_size_f64 + 1.0).ln() - freq_f64.ln();
+            (symbol, idf_val)
+        })
+        .collect()
+}
+
+/// BM25L IDF.
+pub fn calc_idf_l(
+    nd: AHashMap<DefaultSymbol, u32>,
+    corpus_size: usize,
+) -> AHashMap<DefaultSymbol, f64> {
+    let corpus_size_f64 = corpus_size as f64;
+
+    nd.into_iter()
+        .map(|(symbol, freq)| {
+            let freq_f64 = freq as f64;
+            let idf_val = (corpus_size_f64 + 1.0).ln() - (freq_f64 + 0.5).ln();
+            (symbol, idf_val)
+        })
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,15 @@ use pyo3::prelude::*;
 mod bm25l;
 mod bm25okapi;
 mod bm25plus;
+mod index;
 mod optimizations;
+mod scoring;
 
 /// A Python module implemented in Rust.
 #[pymodule]
 pub fn _bm25_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<bm25okapi::BM25Okapi>()?;
+    m.add_class::<bm25okapi::PyPreprocessedQuery>()?;
     m.add_class::<bm25plus::BM25Plus>()?;
     m.add_class::<bm25l::BM25L>()?;
     Ok(())

--- a/src/optimizations.rs
+++ b/src/optimizations.rs
@@ -1,32 +1,56 @@
 // Additional optimization utilities for BM25 implementations
 
 use rayon::prelude::*;
-use smallvec::SmallVec;
 use string_interner::DefaultSymbol;
 
-/// Optimized query preprocessing that can be reused across multiple documents
-#[derive(Clone)]
-pub struct PreprocessedQuery {
-    pub symbols: SmallVec<[DefaultSymbol; 8]>,
-    pub idf_values: SmallVec<[(DefaultSymbol, f64); 8]>,
-    pub is_empty: bool,
+/// Partial top-k selection using nth_element-style partial sort.
+pub fn select_top_k_indices(scores: &[f64], k: usize) -> Vec<usize> {
+    if k >= scores.len() {
+        let mut indices: Vec<usize> = (0..scores.len()).collect();
+        indices.par_sort_unstable_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+        return indices;
+    }
+
+    let mut indexed_scores: Vec<(usize, f64)> = scores
+        .iter()
+        .enumerate()
+        .map(|(i, &score)| (i, score))
+        .collect();
+
+    indexed_scores.select_nth_unstable_by(k, |a, b| b.1.partial_cmp(&a.1).unwrap());
+    indexed_scores[..k].sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+    indexed_scores[..k].iter().map(|(i, _)| *i).collect()
 }
 
-impl PreprocessedQuery {
-    pub fn new() -> Self {
-        Self {
-            symbols: SmallVec::new(),
-            idf_values: SmallVec::new(),
-            is_empty: true,
-        }
+/// Flat parallel document scoring (avoids nested rayon parallelism).
+pub fn score_documents_flat<F>(
+    corpus_size: usize,
+    chunk_size: usize,
+    scorer: F,
+) -> Vec<f64>
+where
+    F: Fn(usize) -> f64 + Sync,
+{
+    if corpus_size == 0 {
+        return Vec::new();
     }
-    
-    pub fn len(&self) -> usize {
-        self.idf_values.len()
-    }
+
+    let effective_chunk = chunk_size.max(1);
+    let chunk_starts: Vec<usize> = (0..corpus_size).step_by(effective_chunk).collect();
+
+    let chunk_scores: Vec<Vec<f64>> = chunk_starts
+        .into_par_iter()
+        .map(|start| {
+            let end = (start + effective_chunk).min(corpus_size);
+            (start..end).map(|i| scorer(i)).collect()
+        })
+        .collect();
+
+    chunk_scores.into_iter().flatten().collect()
 }
 
-/// SIMD-friendly scoring function for better performance on modern CPUs
+/// Legacy alias kept for compatibility with existing chunked API tests.
 #[inline(always)]
 pub fn compute_bm25_score_vectorized(
     query_terms: &[(DefaultSymbol, f64)],
@@ -35,7 +59,6 @@ pub fn compute_bm25_score_vectorized(
     norm_factor: f64,
     k1_plus1: f64,
 ) -> f64 {
-    // Unroll the loop for better performance with small query sizes
     match query_terms.len() {
         0 => 0.0,
         1 => {
@@ -61,23 +84,20 @@ pub fn compute_bm25_score_vectorized(
             }
             score
         }
-        _ => {
-            // For longer queries, use the standard loop
-            query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
-                if let Some(&freq) = doc_freq.get(&symbol) {
-                    let freq_f64 = freq as f64;
-                    let numerator = freq_f64 * k1_plus1;
-                    let denominator = freq_f64 + norm_factor;
-                    score + idf_val * (numerator / denominator)
-                } else {
-                    score
-                }
-            })
-        }
+        _ => query_terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
+            if let Some(&freq) = doc_freq.get(&symbol) {
+                let freq_f64 = freq as f64;
+                let numerator = freq_f64 * k1_plus1;
+                let denominator = freq_f64 + norm_factor;
+                score + idf_val * (numerator / denominator)
+            } else {
+                score
+            }
+        }),
     }
 }
 
-/// Cache-friendly batch processing for better memory access patterns
+/// Chunked parallel scoring without nested rayon pools.
 pub fn process_documents_in_chunks<F>(
     total_docs: usize,
     chunk_size: usize,
@@ -86,35 +106,18 @@ pub fn process_documents_in_chunks<F>(
 where
     F: Fn(usize, usize) -> Vec<f64> + Send + Sync,
 {
-    let chunks: Vec<(usize, usize)> = (0..total_docs)
-        .step_by(chunk_size)
-        .map(|start| (start, (start + chunk_size).min(total_docs)))
-        .collect();
-
-    chunks
-        .into_par_iter()
-        .flat_map(|(start, end)| processor(start, end))
-        .collect()
-}
-
-/// Optimized top-k selection using partial sorting
-pub fn select_top_k_indices(scores: &[f64], k: usize) -> Vec<usize> {
-    if k >= scores.len() {
-        let mut indices: Vec<usize> = (0..scores.len()).collect();
-        indices.par_sort_unstable_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
-        return indices;
+    if total_docs == 0 {
+        return Vec::new();
     }
 
-    // Use partial sort for better performance when k << n
-    let mut indexed_scores: Vec<(usize, f64)> = scores
-        .iter()
-        .enumerate()
-        .map(|(i, &score)| (i, score))
-        .collect();
+    let effective_chunk = chunk_size.max(1);
+    let chunk_starts: Vec<usize> = (0..total_docs).step_by(effective_chunk).collect();
 
-    // Partial sort - only sort the top k elements
-    indexed_scores.select_nth_unstable_by(k, |a, b| b.1.partial_cmp(&a.1).unwrap());
-    indexed_scores[..k].sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-
-    indexed_scores[..k].iter().map(|(i, _)| *i).collect()
+    chunk_starts
+        .into_par_iter()
+        .flat_map(|start| {
+            let end = (start + effective_chunk).min(total_docs);
+            processor(start, end)
+        })
+        .collect()
 }

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,0 +1,369 @@
+//! BM25 scoring engines: inverted-index accumulation, brute-force fallback, and top-k.
+
+use crate::index::IndexView;
+use ahash::AHashMap;
+use rayon::prelude::*;
+use smallvec::SmallVec;
+use std::cmp::Ordering;
+use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
+
+/// Preprocessed query terms with resolved IDF values.
+#[derive(Clone)]
+pub struct PreprocessedQuery {
+    pub terms: SmallVec<[(DefaultSymbol, f64); 8]>,
+}
+
+impl PreprocessedQuery {
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.terms.len()
+    }
+}
+
+/// BM25 scoring formula variant.
+#[derive(Clone, Copy)]
+pub enum ScoreFormula {
+    Okapi,
+    Plus { delta: f64 },
+    L { delta: f64 },
+}
+
+/// Shared scoring parameters precomputed at index construction.
+#[derive(Clone, Copy)]
+pub struct ScoreParams {
+    pub k1: f64,
+    pub k1_plus1: f64,
+    pub one_minus_b: f64,
+    pub b_over_avgdl: f64,
+}
+
+impl ScoreParams {
+    pub fn norm_factor(&self, dl: f64) -> f64 {
+        self.k1 * (self.one_minus_b + self.b_over_avgdl * dl)
+    }
+}
+
+/// Build a preprocessed query from string terms.
+pub fn preprocess_query(
+    query: &[String],
+    interner: &StringInterner<DefaultBackend>,
+    idf: &AHashMap<DefaultSymbol, f64>,
+) -> PreprocessedQuery {
+    let terms: SmallVec<[(DefaultSymbol, f64); 8]> = query
+        .iter()
+        .filter_map(|term| interner.get(term))
+        .filter_map(|symbol| idf.get(&symbol).map(|&idf_val| (symbol, idf_val)))
+        .collect();
+
+    PreprocessedQuery { terms }
+}
+
+#[inline(always)]
+pub fn term_score_okapi(freq: u32, dl: f64, params: ScoreParams, idf: f64) -> f64 {
+    let freq_f64 = freq as f64;
+    let norm_factor = params.norm_factor(dl);
+    let numerator = freq_f64 * params.k1_plus1;
+    let denominator = freq_f64 + norm_factor;
+    idf * (numerator / denominator)
+}
+
+#[inline(always)]
+pub fn term_score_plus(freq: u32, dl: f64, params: ScoreParams, idf: f64, delta: f64) -> f64 {
+    let freq_f64 = freq as f64;
+    let norm_factor = params.norm_factor(dl);
+    let numerator = delta + freq_f64 * params.k1_plus1;
+    let denominator = norm_factor + freq_f64;
+    idf * (numerator / denominator)
+}
+
+#[inline(always)]
+pub fn term_score_l(freq: u32, dl: f64, params: ScoreParams, idf: f64, delta: f64) -> f64 {
+    let freq_f64 = freq as f64;
+    let denominator = params.one_minus_b + params.b_over_avgdl * dl;
+    let ctd = if denominator > 0.0 {
+        freq_f64 / denominator
+    } else {
+        0.0
+    };
+    let numerator = params.k1_plus1 * (ctd + delta);
+    let denom = params.k1 + ctd + delta;
+    if denom > 0.0 {
+        idf * numerator / denom
+    } else {
+        0.0
+    }
+}
+
+#[inline(always)]
+fn term_score(
+    formula: ScoreFormula,
+    freq: u32,
+    dl: f64,
+    params: ScoreParams,
+    idf: f64,
+) -> f64 {
+    match formula {
+        ScoreFormula::Okapi => term_score_okapi(freq, dl, params, idf),
+        ScoreFormula::Plus { delta } => term_score_plus(freq, dl, params, idf, delta),
+        ScoreFormula::L { delta } => term_score_l(freq, dl, params, idf, delta),
+    }
+}
+
+/// SIMD-friendly batch accumulation for a posting list (4-wide unrolled).
+#[inline]
+fn accumulate_postings_simd(
+    scores: &mut [f64],
+    doc_len: &[u32],
+    postings: &[(u32, u32)],
+    idf: f64,
+    params: ScoreParams,
+    formula: ScoreFormula,
+) {
+    let mut i = 0;
+    let len = postings.len();
+
+    while i + 4 <= len {
+        for j in 0..4 {
+            let (doc_id, freq) = postings[i + j];
+            let idx = doc_id as usize;
+            let dl = doc_len[idx] as f64;
+            scores[idx] += term_score(formula, freq, dl, params, idf);
+        }
+        i += 4;
+    }
+
+    while i < len {
+        let (doc_id, freq) = postings[i];
+        let idx = doc_id as usize;
+        let dl = doc_len[idx] as f64;
+        scores[idx] += term_score(formula, freq, dl, params, idf);
+        i += 1;
+    }
+}
+
+/// Score all documents using the inverted index (sparse query-friendly).
+pub fn score_all_inverted(
+    index: &IndexView<'_>,
+    query: &PreprocessedQuery,
+    params: ScoreParams,
+    formula: ScoreFormula,
+) -> Vec<f64> {
+    if query.is_empty() {
+        return vec![0.0; index.corpus_size];
+    }
+
+    let mut scores = vec![0.0; index.corpus_size];
+
+    for &(symbol, idf) in &query.terms {
+        if let Some(postings) = index.inverted.get(&symbol) {
+            accumulate_postings_simd(
+                &mut scores,
+                index.doc_len,
+                postings,
+                idf,
+                params,
+                formula,
+            );
+        }
+    }
+
+    scores
+}
+
+/// Score all documents with parallel brute-force scan.
+pub fn score_documents_parallel(
+    doc_ids: &[usize],
+    doc_freqs: &[AHashMap<DefaultSymbol, u32>],
+    doc_len: &[u32],
+    query: &PreprocessedQuery,
+    params: ScoreParams,
+    formula: ScoreFormula,
+) -> Vec<f64> {
+    if query.is_empty() {
+        return vec![0.0; doc_ids.len()];
+    }
+
+    doc_ids
+        .par_iter()
+        .map(|&i| {
+            let doc_freq = &doc_freqs[i];
+            let dl = doc_len[i] as f64;
+
+            query.terms.iter().fold(0.0, |score, &(symbol, idf_val)| {
+                if let Some(&freq) = doc_freq.get(&symbol) {
+                    score + term_score(formula, freq, dl, params, idf_val)
+                } else {
+                    score
+                }
+            })
+        })
+        .collect()
+}
+
+/// Top-k over candidate documents from inverted index posting unions.
+pub fn top_k_inverted(
+    index: &IndexView<'_>,
+    query: &PreprocessedQuery,
+    params: ScoreParams,
+    formula: ScoreFormula,
+    k: usize,
+) -> Vec<(usize, f64)> {
+    if k == 0 {
+        return Vec::new();
+    }
+
+    if query.is_empty() {
+        return (0..index.corpus_size.min(k))
+            .map(|doc_id| (doc_id, 0.0))
+            .collect();
+    }
+
+    let mut candidate_scores: AHashMap<u32, f64> = AHashMap::new();
+
+    for &(symbol, idf) in &query.terms {
+        if let Some(postings) = index.inverted.get(&symbol) {
+            for &(doc_id, freq) in postings {
+                let dl = index.doc_len[doc_id as usize] as f64;
+                let contribution = term_score(formula, freq, dl, params, idf);
+                *candidate_scores.entry(doc_id).or_insert(0.0) += contribution;
+            }
+        }
+    }
+
+    let mut results: Vec<(usize, f64)> = candidate_scores
+        .into_iter()
+        .map(|(doc_id, score)| (doc_id as usize, score))
+        .collect();
+
+    results.sort_by(|a, b| {
+        b.1
+            .partial_cmp(&a.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    if results.len() < k {
+        let mut included: AHashMap<usize, ()> =
+            results.iter().map(|(doc_id, _)| (*doc_id, ())).collect();
+        for doc_id in 0..index.corpus_size {
+            if results.len() >= k {
+                break;
+            }
+            if !included.contains_key(&doc_id) {
+                results.push((doc_id, 0.0));
+                included.insert(doc_id, ());
+            }
+        }
+    }
+
+    results.truncate(k);
+    results
+}
+
+/// Batch scoring for multiple queries against the same index.
+pub fn score_queries_batch(
+    index: &IndexView<'_>,
+    queries: &[PreprocessedQuery],
+    params: ScoreParams,
+    formula: ScoreFormula,
+) -> Vec<Vec<f64>> {
+    queries
+        .par_iter()
+        .map(|query| score_all_inverted(index, query, params, formula))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::build_index;
+    use ahash::AHashMap;
+    use smallvec::smallvec;
+    use string_interner::{DefaultBackend, StringInterner};
+
+    fn sample_index() -> (
+        IndexView<'static>,
+        StringInterner<DefaultBackend>,
+        AHashMap<DefaultSymbol, f64>,
+    ) {
+        let corpus = vec![
+            smallvec!["hello".to_string(), "world".to_string()],
+            smallvec!["hello".to_string(), "rust".to_string()],
+            smallvec!["world".to_string(), "bm25".to_string()],
+        ];
+        let mut interner = StringInterner::default();
+        let built = build_index(corpus, &mut interner);
+        let nd = built.nd;
+        let idf = crate::index::calc_idf_okapi(nd, built.corpus_size, 0.25);
+
+        let doc_freqs = built.doc_freqs;
+        let doc_len = built.doc_len;
+        let inverted = built.inverted;
+        let corpus_size = built.corpus_size;
+        let avgdl = built.avgdl;
+
+        let view = IndexView {
+            doc_freqs: Box::leak(doc_freqs.into_boxed_slice()),
+            doc_len: Box::leak(doc_len.into_boxed_slice()),
+            inverted: Box::leak(Box::new(inverted)),
+            corpus_size,
+            avgdl,
+        };
+
+        (view, interner, idf)
+    }
+
+    #[test]
+    fn inverted_scores_match_brute_force() {
+        let (view, interner, idf) = sample_index();
+        let query = preprocess_query(
+            &["hello".to_string(), "world".to_string()],
+            &interner,
+            &idf,
+        );
+        let params = ScoreParams {
+            k1: 1.5,
+            k1_plus1: 2.5,
+            one_minus_b: 0.25,
+            b_over_avgdl: 0.75 / view.avgdl,
+        };
+
+        let inverted_scores = score_all_inverted(&view, &query, params, ScoreFormula::Okapi);
+        let brute_scores = score_documents_parallel(
+            &(0..view.corpus_size).collect::<Vec<_>>(),
+            view.doc_freqs,
+            view.doc_len,
+            &query,
+            params,
+            ScoreFormula::Okapi,
+        );
+
+        for (a, b) in inverted_scores.iter().zip(brute_scores.iter()) {
+            assert!((a - b).abs() < 1e-12, "scores differ: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn top_k_returns_highest_scores() {
+        let (view, interner, idf) = sample_index();
+        let query = preprocess_query(&["hello".to_string()], &interner, &idf);
+        let params = ScoreParams {
+            k1: 1.5,
+            k1_plus1: 2.5,
+            one_minus_b: 0.25,
+            b_over_avgdl: 0.75 / view.avgdl,
+        };
+
+        let all_scores = score_all_inverted(&view, &query, params, ScoreFormula::Okapi);
+        let top = top_k_inverted(&view, &query, params, ScoreFormula::Okapi, 2);
+
+        assert_eq!(top.len(), 2);
+        let mut sorted: Vec<_> = all_scores.iter().enumerate().collect();
+        sorted.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
+        assert_eq!(top[0].0, sorted[0].0);
+        assert_eq!(top[1].0, sorted[1].0);
+    }
+}

--- a/tests/test_perf_equivalence.py
+++ b/tests/test_perf_equivalence.py
@@ -1,0 +1,155 @@
+"""
+Performance and API equivalence tests for optimized BM25 paths.
+"""
+
+import concurrent.futures
+import random
+import string
+
+import pytest
+
+try:
+    from bm25_rs import BM25L, BM25Okapi, BM25Plus, PyPreprocessedQuery
+except ImportError:
+    pytest.skip("BM25-RS not available", allow_module_level=True)
+
+
+def _make_corpus(n_docs: int = 200, vocab_size: int = 500) -> list[str]:
+    random.seed(42)
+    vocab = [
+        "".join(random.choices(string.ascii_lowercase, k=5))
+        for _ in range(vocab_size)
+    ]
+    return [
+        " ".join(random.choices(vocab, k=20))
+        for _ in range(n_docs)
+    ]
+
+
+@pytest.fixture(scope="module")
+def large_corpus():
+    return _make_corpus()
+
+
+@pytest.fixture(scope="module")
+def bm25(large_corpus):
+    return BM25Okapi(large_corpus)
+
+
+class TestScoringEquivalence:
+    def test_chunked_matches_scores(self, bm25):
+        query = ["term", "search", "document"]
+        scores = bm25.get_scores(query)
+        chunked = bm25.get_scores_chunked(query, chunk_size=37)
+        assert len(chunked) == len(scores)
+        for a, b in zip(scores, chunked):
+            assert abs(a - b) < 1e-10
+
+    def test_batch_matches_scores(self, bm25, large_corpus):
+        query = ["term", "search"]
+        doc_ids = list(range(0, len(large_corpus), 7))
+        batch = bm25.get_batch_scores(query, doc_ids)
+        all_scores = bm25.get_scores(query)
+        for i, doc_id in enumerate(doc_ids):
+            assert abs(batch[i] - all_scores[doc_id]) < 1e-10
+
+    def test_top_n_indices_agrees_with_scores(self, bm25, large_corpus):
+        query = ["gtwcl", "ytfnn", "ptreu"]
+        scores = bm25.get_scores(query)
+        top_indices = bm25.get_top_n_indices(query, n=5)
+        top_docs = bm25.get_top_n(query, large_corpus, n=5)
+
+        assert len(top_indices) == 5
+        assert len(top_docs) == 5
+
+        for (idx, score), (doc, doc_score) in zip(top_indices, top_docs):
+            assert doc == large_corpus[idx]
+            assert abs(score - doc_score) < 1e-10
+            assert abs(score - scores[idx]) < 1e-10
+
+    def test_preprocessed_query_matches_scores(self, bm25):
+        query = ["gtwcl", "ytfnn"]
+        preprocessed = bm25.preprocess_query(query)
+        assert isinstance(preprocessed, PyPreprocessedQuery)
+        assert len(preprocessed) > 0
+
+        direct = bm25.get_scores(query)
+        via_preprocessed = bm25.get_scores_with_preprocessed(preprocessed)
+        assert direct == via_preprocessed
+
+    def test_batch_queries_matches_individual(self, bm25):
+        queries = [["term", "search"], ["document", "query"], ["random", "words"]]
+        batch = bm25.get_scores_batch(queries)
+        assert len(batch) == len(queries)
+        for q, scores in zip(queries, batch):
+            assert scores == bm25.get_scores(q)
+
+
+class TestTokenizedCorpus:
+    def test_from_tokenized_corpus(self, large_corpus):
+        tokenized = [doc.lower().split() for doc in large_corpus[:50]]
+        bm25 = BM25Okapi(tokenized_corpus=tokenized)
+        assert bm25.corpus_size == 50
+
+        query = ["term", "search"]
+        scores = bm25.get_scores(query)
+        assert len(scores) == 50
+
+
+class TestVariantParity:
+    @pytest.mark.parametrize("cls", [BM25Okapi, BM25Plus, BM25L])
+    def test_top_n_indices_available(self, cls, large_corpus):
+        bm25 = cls(large_corpus[:30])
+        query = ["gtwcl", "ytfnn"]
+        top = bm25.get_top_n_indices(query, n=3)
+        assert len(top) == 3
+        assert all(isinstance(idx, int) and isinstance(score, float) for idx, score in top)
+
+    @pytest.mark.parametrize("cls", [BM25Okapi, BM25Plus, BM25L])
+    def test_chunked_available(self, cls, large_corpus):
+        bm25 = cls(large_corpus[:30])
+        query = ["term"]
+        scores = bm25.get_scores(query)
+        chunked = bm25.get_scores_chunked(query)
+        assert scores == chunked
+
+
+class TestNumpyOutput:
+    def test_get_scores_numpy(self, bm25):
+        pytest.importorskip("numpy")
+        import numpy as np
+
+        query = ["term", "search"]
+        arr = bm25.get_scores_numpy(query)
+        scores = bm25.get_scores(query)
+
+        assert isinstance(arr, np.ndarray)
+        assert arr.dtype == np.float64
+        assert arr.shape == (bm25.corpus_size,)
+        assert np.allclose(arr, scores)
+
+
+class TestConcurrency:
+    def test_concurrent_queries(self, bm25):
+        queries = [["term", "search"], ["document", "query"], ["random", "token"]] * 4
+
+        def run_query(q):
+            return sum(bm25.get_scores(q))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(run_query, queries))
+
+        expected = [sum(bm25.get_scores(q)) for q in queries]
+        assert results == expected
+
+
+@pytest.mark.benchmark(group="scoring")
+def test_benchmark_get_scores(benchmark, bm25):
+    query = ["term", "search", "document"]
+    benchmark(bm25.get_scores, query)
+
+
+@pytest.mark.benchmark(group="topk")
+def test_benchmark_top_n_indices(benchmark, bm25):
+    query = ["term", "search", "document"]
+    benchmark(bm25.get_top_n_indices, query, n=10)


### PR DESCRIPTION
Refactor Okapi/Plus/L onto shared index and scoring layers with GIL release, NumPy output, batch/preprocessed query APIs, CI pytest, and perf equivalence tests.